### PR TITLE
FIX blocking IP end of connection

### DIFF
--- a/iec870ree/ip.py
+++ b/iec870ree/ip.py
@@ -56,8 +56,14 @@ class Ip(PhysicalLayer):
         """Read bytes from socket
         """
         logger.debug("Start reading port for %s", self.addr)
+        self.connection.settimeout(10.0)
         while self.alive.is_set():
-            response = self.connection.recv(16)
+            try:
+                response = self.connection.recv(16)
+            except socket.timeout as e:
+                continue
+            except Exception as e:
+                continue
             if not response:
                 continue
             logger.debug(


### PR DESCRIPTION
Receive thread is blocking after end of comminication. It must be "non_blocking" to allow thread clean exit.

Copyed from gisce/iec870ree_moxa#4