### PR TITLE
Imp empty times (zero values)

### DIFF
--- a/iec870ree/app_asdu.py
+++ b/iec870ree/app_asdu.py
@@ -594,10 +594,12 @@ class TimeA(TimeBase):
         self.RES1 = bitstring.BitArray(reversed(reversed_bits.read(2))).uint
         self.SU = reversed_bits.read(1).uint
         self.dayofmonth = bitstring.BitArray(reversed(reversed_bits.read(5)))\
-                                   .uint
+                                   .uint or 1
         self.dayofweek = bitstring.BitArray(reversed(reversed_bits.read(3)))\
                                   .uint
-        self.month = bitstring.BitArray(reversed(reversed_bits.read(4))).uint
+        self.month = bitstring.BitArray(
+            reversed(reversed_bits.read(4))
+        ).uint or 1
         self.ETI = bitstring.BitArray(reversed(reversed_bits.read(2))).uint
         self.PTI = bitstring.BitArray(reversed(reversed_bits.read(2))).uint
         self.year = bitstring.BitArray(reversed(reversed_bits.read(7))).uint
@@ -654,9 +656,13 @@ class TimeB(TimeBase):
         self.hour = bitstring.BitArray(reversed(reversed_bits.read(5))).uint
         self.RES1 = bitstring.BitArray(reversed(reversed_bits.read(2))).uint
         self.SU = reversed_bits.read(1).uint
-        self.dayofmonth = bitstring.BitArray(reversed(reversed_bits.read(5))).uint
+        self.dayofmonth = bitstring.BitArray(
+            reversed(reversed_bits.read(5))
+        ).uint or 1
         self.dayofweek = bitstring.BitArray(reversed(reversed_bits.read(3))).uint
-        self.month = bitstring.BitArray(reversed(reversed_bits.read(4))).uint
+        self.month = bitstring.BitArray(
+            reversed(reversed_bits.read(4))
+        ).uint or 1
         self.ETI = bitstring.BitArray(reversed(reversed_bits.read(2))).uint
         self.PTI = bitstring.BitArray(reversed(reversed_bits.read(2))).uint
         self.year = bitstring.BitArray(reversed(reversed_bits.read(7))).uint

--- a/tests/test_app_asdu.py
+++ b/tests/test_app_asdu.py
@@ -51,6 +51,18 @@ class TestAppAsdu(unittest.TestCase):
             localize(datetime.datetime(2010,2,7,11,0))
         )
 
+    def test_empty_time_a_from_hex(self):
+        tiempo = app_asdu.TimeA()
+
+        # 2000 0 0 0 0 0
+        tiempo.from_hex(bytearray.fromhex("00 00 00 00 00"))
+        print(tiempo)
+        self.assertEqual(
+            tiempo.datetime,
+            localize(datetime.datetime(2000, 1, 1, 0 ,0 ,0 , 0))
+        )
+
+
     def test_time_b_from_hex(self):
         tiempo = app_asdu.TimeB()
 
@@ -67,6 +79,17 @@ class TestAppAsdu(unittest.TestCase):
         self.assertEqual(
             tiempo.datetime,
             localize(datetime.datetime(2010, 2, 7, 11, 16, 10, 522000))
+        )
+
+    def test_empty_time_b_from_hex(self):
+        tiempo = app_asdu.TimeB()
+
+        # 2000 0 0 0 0 0
+        tiempo.from_hex(bytearray.fromhex("00 00 00 00 00 00 00"))
+        print(tiempo)
+        self.assertEqual(
+            tiempo.datetime,
+            localize(datetime.datetime(2000, 1, 1, 0 ,0 ,0 , 0))
         )
 
     def test_time_a_to_bytes(self):


### PR DESCRIPTION
Some meters return empty TimeA and TimeB structs (all zeroes). They are now converted to 2000-01-01 00:00:00.0 valid dates