### PR TITLE
IMP Wait a while before protocol start

### DIFF
--- a/iec870ree/ip.py
+++ b/iec870ree/ip.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 import logging
 import socket
+import time
 import six
 if six.PY2:
     import Queue as queue
@@ -40,6 +41,7 @@ class Ip(PhysicalLayer):
         self.alive.set()
         self.thread.start()
         logger.debug("Connection with %s created", self.addr)
+        time.sleep(5)
 
     def disconnect(self):
         """Disconnects


### PR DESCRIPTION
Some meters accessible by IP needs a little amount of time before start iec870ree protocol. We add 5 seconds of delay before start handshake with meter. 