### PR TITLE
IMP Skip spurious packets starting with FF

### DIFF
--- a/iec870ree/base_asdu.py
+++ b/iec870ree/base_asdu.py
@@ -13,6 +13,8 @@ class AsduParser:
 
     def append_and_get_if_completed(self, bt):
         if self.asdu is None:
+            if bt == 255:
+                return None
             self.create_asdu(bt)
 
         if self.asdu.append(bt):


### PR DESCRIPTION
Some buggy meters sends bad packets starting with 0xFF. We skip this packets to avoid errors.