### PR TITLE
ADD Last Content Timemout & connection duration

### DIFF
--- a/examples/ip_cliente.py
+++ b/examples/ip_cliente.py
@@ -21,6 +21,7 @@ def run_example(ip, port, der, dir_pm, clave_pm):
         link_layer = iec870ree.protocol.LinkLayer(der, dir_pm)
         link_layer.initialize(physical_layer)
         app_layer = iec870ree.protocol.AppLayer()
+        app_layer.set_content_timeout(300)
         app_layer.initialize(link_layer)
 
         physical_layer.connect()
@@ -60,15 +61,15 @@ def run_example(ip, port, der, dir_pm, clave_pm):
         #for resp in app_layer.read_incremental_values(datetime.datetime(2021, 4, 1, 0, 0, 0), datetime.datetime.now(), register='daily_billings'):
         #    logging.info("Daily billings response {}".format(resp))
 
-        ##### DAILY BILLINGS
+        ##### CURVES
         #logging.info("GETTING DAILY BILLINGS")
         # ABSOLUTE (122)
-        #for resp in app_layer.read_absolute_values(datetime.datetime(2020,2,1,0,0,0), datetime.datetime.now(), register='daily_billings'):
+        #for resp in app_layer.read_absolute_values(datetime.datetime(2020,2,1,0,0,0), datetime.datetime.now(), register='profiles'):
         #    logging.info("Daily billings response {}".format(resp))
-        # INCREMENTAL (123)
-        #logging.info("LEER CURVA DESDE ABRIL")
-        #for resp in app_layer.read_incremental_values(datetime.datetime(2021, 4, 18, 0, 0, 0), datetime.datetime.now(), register='profiles'):
-        #    logging.info("Daily billings response {}".format(resp))
+        #INCREMENTAL (123)
+        logging.info("LEER CURVA")
+        for resp in app_layer.read_incremental_values(datetime.datetime(2021, 4, 18, 0, 0, 0), datetime.datetime.now(), register='profiles'):
+            logging.info("Profile response {}".format(resp))
 
         #### SET TIME ####
         #resp = app_layer.read_datetime()

--- a/iec870ree/protocol.py
+++ b/iec870ree/protocol.py
@@ -158,6 +158,7 @@ class AppLayer(with_metaclass(ABCMeta)):
             yield asdu_resp
 
             if not isinstance(asdu_resp, VariableAsdu):
+                self.check_content_timeout()
                 continue
             if asdu_resp.causa_tm == 0x05 and asdu_resp.tipo in [
                 M_TA_VC_2.type, M_TA_VM_2.type, M_IT_TK_2.type, M_IT_TG_2.type,


### PR DESCRIPTION
AppLayer stores two time counters:

* **Total Connection Duration**: Time from AppLayer instantiation
* **Last Content Hearbeat**: Time from last content from meter

When *Last Content Heartbeat* is greater than a configured amount of seconds (stored in `max_content_timeout` variable), `NoContentTimeoutException` is raised

`max_content_timeout` may be set with `set_content_timeout` and is 300 seconds by default

`read_incremental_values`, `read_absolute_values` , `stored_tariff_info` and `current_tariff_info` functions calls `reset_content_received` when correct data is received to reset content counter and avoid timeout

