### PR TITLE
Opticalphysicallayer

### DIFF
--- a/examples/serial_cliente.py
+++ b/examples/serial_cliente.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     argv = sys.argv[1:]
     try:
         argv = sys.argv[1:]
-        opts, args = getopt.getopt(argv,"hp:n:d:p:c:",
+        opts, args = getopt.getopt(argv,"t:d:p:c:",
                                    ["port=", "der=", "dir_pm=",
                                    "clave_pm="])
     except getopt.GetoptError:
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         if opt == '-h':
           logging.error("help not implemented")
           sys.exit()
-        elif opt in ("-p", "--port"):
+        elif opt in ("-t", "--port"):
           port = arg
         elif opt in ("-d", "--der"):
           der = int(arg)

--- a/examples/serial_cliente.py
+++ b/examples/serial_cliente.py
@@ -1,0 +1,68 @@
+import sys
+import logging
+from os.path import dirname, realpath, sep, pardir
+library_path = dirname(realpath(__file__)) + sep + pardir
+sys.path.append(library_path)
+
+import getopt
+import logging
+import iec870ree
+import iec870ree.serial
+import iec870ree.protocol
+import datetime
+
+def run_example(port, der, dir_pm, clave_pm):
+    end_date = datetime.datetime.now()
+    start_date = end_date - datetime.timedelta(days = 2)
+    
+    physical_layer = iec870ree.serial.Serial(port)
+    link_layer = iec870ree.protocol.LinkLayer(der, dir_pm)
+    link_layer.initialize(physical_layer)
+    app_layer = iec870ree.protocol.AppLayer()
+    app_layer.initialize(link_layer)
+
+    physical_layer.connect()
+    link_layer.link_state_request()
+    link_layer.remote_link_reposition()
+    logging.info("before authentication")
+    resp = app_layer.authenticate(clave_pm)
+    logging.info("CLIENTE authenticate response {}".format(resp))
+    logging.info("before read")
+    for resp in app_layer.read_integrated_totals(start_date, end_date):
+        logging.info("read response {}".format(resp))
+    app_layer.finish_session()
+    physical_layer.disconnect()
+    
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    
+    argv = sys.argv[1:]
+    try:
+        argv = sys.argv[1:]
+        opts, args = getopt.getopt(argv,"hp:n:d:p:c:",
+                                   ["port=", "der=", "dir_pm=",
+                                   "clave_pm="])
+    except getopt.GetoptError:
+       logging.error('wrong command')
+       sys.exit(2)
+
+    port = "/dev/ttyUSB0"
+    der = None
+    dir_pm = None
+    clave_pm = None
+    for opt, arg in opts:
+        if opt == '-h':
+          logging.error("help not implemented")
+          sys.exit()
+        elif opt in ("-p", "--port"):
+          port = arg
+        elif opt in ("-d", "--der"):
+          der = int(arg)
+        elif opt in ("-p", "--dir_pm"):
+          dir_pm = int(arg)
+        elif opt in ("-c", "--clave_pm"):
+          clave_pm = int(arg)
+
+    logging.info('Started {} {} {} {}'.format(port, der, dir_pm,
+                                                 clave_pm))
+    run_example(port, der, dir_pm, clave_pm)

--- a/iec870ree/serial.py
+++ b/iec870ree/serial.py
@@ -20,7 +20,6 @@ class Serial(PhysicalLayer):
     def __init__(self, serial_port='/dev/ttyUSB0'):
         self.serial_port = serial_port
         self.connected = False
-        self.data_mode = False
         self.queue = queue.Queue()
  
     def connect(self):
@@ -61,26 +60,17 @@ class Serial(PhysicalLayer):
             return
 
         try:
-            if self.data_mode:
-                self.data_mode = False
             self.sport.close()
         finally:
-            self.data_mode = False
             self.connected = False
 
     def send_byte(self, bt):
-        if not self.data_mode:
-            raise SerialException("serial not in datamode")
         self.write(bytes([bt]))
 
     def send_bytes(self, bt):
-        if not self.data_mode:
-            raise SerialException("serial not in datamode")
         self.write(bt)
         
     def get_byte(self, timeout = 60):
-        if not self.data_mode:
-            raise SerialException("serial not in datamode")
         return self.queue.get(True, timeout)
 
     def write(self, value):
@@ -101,15 +91,7 @@ class Serial(PhysicalLayer):
 
             for b in response:
                 # if not self.data_mode and (b == 0x0A or b == 0x0D):
-                if not self.data_mode:
-                    # answer with the line
-                    buffer.append(b)
-                    if (b == 0x0A):
-                        logger.info("R-" + buffer.decode("ascii"))
-                        read_queue.put(buffer.decode("ascii"))
-                        del buffer[:]
-                else:
-                    read_queue.put(b)
+                read_queue.put(b)
 
         logger.info("read thread END")
 

--- a/iec870ree/serial.py
+++ b/iec870ree/serial.py
@@ -1,0 +1,140 @@
+from .protocol import PhysicalLayer
+import threading
+import six
+if six.PY2:
+    import Queue as queue
+else:
+    import queue
+import serial
+import time
+import logging
+
+logger = logging.getLogger('iec870ree.serial')
+
+class SerialException(Exception):
+    pass
+
+
+class Serial(PhysicalLayer):
+    CONNECTED_WORDS = ["CONNECT", "REL ASYNC"]
+
+    def __init__(self, serial_port='/dev/ttyUSB0'):
+        self.serial_port = serial_port
+        self.connected = False
+        self.data_mode = False
+        self.queue = queue.Queue()
+ 
+    def connect(self):
+        if (self.connected):
+            return
+
+        try:
+            self.connect_port()
+        except Exception as e:
+            self.disconnect()
+            raise SerialException(e)
+
+    def connect_port(self):
+        max_tries = 20
+        for i in range(max_tries):
+            logger.info("try open port {}".format(i))
+            try:
+                self.sport = serial.Serial(self.serial_port, baudrate=9600,
+                                           timeout=1)
+                logger.info("serial port {} opened".format(self.serial_port))
+                break
+            except serial.serialutil.SerialException as ex:
+                logger.warning("error connectiong {}".format(ex))
+                time.sleep(1)
+                if (i >= max_tries or "Permission" not in str(ex)):
+                    raise ex
+        else:
+            raise SerialException("couldn't connect to port {}".format(
+                self.serial_port))
+                    
+        self.connected = True
+        self.dthread = threading.Thread(target=self.read_port,
+                                        args=(self.queue,))
+        self.dthread.start()
+
+    def waitforconnect(self):
+        max_tries = 40
+        for i in range(max_tries):
+            try:
+                i = self.queue.get(False, 1)
+                logger.info("got message> " + i)
+                for word in Serial.CONNECTED_WORDS:
+                    if word in i:
+                        logger.info("CONNECTED!!!!!!!!!!!!!!!!!!!!")
+                        self.data_mode = True
+                        self.queue.task_done()
+                        time.sleep(5)  # everything smooth in read thread
+                        return
+                self.queue.task_done()
+            except queue.Empty:
+                logger.info("nothing yet...")
+                time.sleep(1)
+        raise SerialException("Error Waiting for connection")
+
+    def disconnect(self):
+        if not self.connected:
+            return
+
+        try:
+            if self.data_mode:
+                self.data_mode = False
+            self.sport.close()
+        finally:
+            self.data_mode = False
+            self.connected = False
+
+    def send_byte(self, bt):
+        if not self.data_mode:
+            raise SerialException("serial not in datamode")
+        self.write(bytes([bt]))
+
+    def send_bytes(self, bt):
+        if not self.data_mode:
+            raise SerialException("serial not in datamode")
+        self.write(bt)
+        
+    def get_byte(self, timeout = 60):
+        if not self.data_mode:
+            raise SerialException("serial not in datamode")
+        return self.queue.get(True, timeout)
+
+    def write(self, value):
+        if not self.connected:
+            raise SerialException("serial not connected")
+        logger.debug("->" + ":".join("%02x" % b for b in bytearray(value)))
+        self.sport.write(value)
+
+    def read_port(self, read_queue):
+        logger.info("read thread Starting")
+        buffer = bytearray()
+        while self.connected:
+            logger.debug("iterate read thread")
+            response = self.sport.read(1)
+            if not response:
+                continue
+            logger.debug("<-" + ":".join("%02x" % b for b in bytearray(response)))
+
+            for b in response:
+                # if not self.data_mode and (b == 0x0A or b == 0x0D):
+                if not self.data_mode:
+                    # answer with the line
+                    buffer.append(b)
+                    if (b == 0x0A):
+                        logger.info("R-" + buffer.decode("ascii"))
+                        read_queue.put(buffer.decode("ascii"))
+                        del buffer[:]
+                else:
+                    read_queue.put(b)
+
+        logger.info("read thread END")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.disconnect()

--- a/iec870ree/serial.py
+++ b/iec870ree/serial.py
@@ -16,7 +16,6 @@ class SerialException(Exception):
 
 
 class Serial(PhysicalLayer):
-    CONNECTED_WORDS = ["CONNECT", "REL ASYNC"]
 
     def __init__(self, serial_port='/dev/ttyUSB0'):
         self.serial_port = serial_port
@@ -56,25 +55,6 @@ class Serial(PhysicalLayer):
         self.dthread = threading.Thread(target=self.read_port,
                                         args=(self.queue,))
         self.dthread.start()
-
-    def waitforconnect(self):
-        max_tries = 40
-        for i in range(max_tries):
-            try:
-                i = self.queue.get(False, 1)
-                logger.info("got message> " + i)
-                for word in Serial.CONNECTED_WORDS:
-                    if word in i:
-                        logger.info("CONNECTED!!!!!!!!!!!!!!!!!!!!")
-                        self.data_mode = True
-                        self.queue.task_done()
-                        time.sleep(5)  # everything smooth in read thread
-                        return
-                self.queue.task_done()
-            except queue.Empty:
-                logger.info("nothing yet...")
-                time.sleep(1)
-        raise SerialException("Error Waiting for connection")
 
     def disconnect(self):
         if not self.connected:


### PR DESCRIPTION
Implementation of a serial physical layer to try to use the optical connector.

WARNING. It doesn’t work on my side. I tested with two optical readers and none of them receive anything from the meter. The meter is hired to our distributor (at home) and I’ve the feeling it is manipulated to block the optical interface or something like that. Anyway, I’m pushing for anyone else to test this simple code.