### PR TITLE
Add protocol month/year on ASDU 71

### DIFF
--- a/iec870ree/app_asdu.py
+++ b/iec870ree/app_asdu.py
@@ -273,6 +273,7 @@ class P_MP_NA_2(BaseAppAsdu):
     data_length = 0x06
 
     def __init__(self):
+        self.ano_standard = None
         self.codigo_fabricante = None
         self.codigo_equipo = None
 
@@ -280,6 +281,8 @@ class P_MP_NA_2(BaseAppAsdu):
         return bytes()
 
     def from_hex(self, data, cualificador_ev):
+        std_date = struct.unpack("B", data[0:1])[0]
+        self.ano_standard = '{}/{}'.format(std_date & 15, ((std_date & 240) >> 4) + 2000)
         self.codigo_fabricante = struct.unpack("B", data[1:2])[0]
         self.codigo_equipo = struct.unpack("I", data[2:6])[0]
 


### PR DESCRIPTION
The Month/Year protocol of the ASDU 71 is processed and shown:

```
INFO:iec870ree:received frame ----- VariableAsdu Begin -----
 length: 15
 RES: 0 PRM: 0 FCB: 0 FCV: 0 CF(cod. funcion): 8
 DER: 1
 TIPO: 71 0x47
 cualificador estructura variable: 1
 causa transmision: 5 0x5 P/N: 0
 direccion punto medida: 1
 direccion registro: 0
 CONTENIDO: 24:42:c6:12:e1:02
 -- P_MP_NA_2 Begin --
    ano_standard: 4/2002
    codigo_fabricante: 66
    codigo_equipo: 48304838
 -- P_MP_NA_2 End --
 checksum: 120 0x78
 68:0f:0f:68:08:01:00:47:01:05:01:00:00:24:42:c6:12:e1:02:78:16
----- VariableAsdu End -----
```